### PR TITLE
Get renovate to work with conda envs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
     {
       "description": "Upgrade conda dependencies",
       "fileMatch": [
-        "^(?:workflow/envs/)?\\w+\\.yaml$"
+        "workflow\/envs\/.*yaml"
       ],
       "matchStrings": [
         "# renovate datasource=conda\\sdepName=(?<depName>.*?)\\s+- [a-z0-9]+==\"?(?<currentValue>.*)\"?"


### PR DESCRIPTION
## What?

Have renovate find conda env files and update the annotated deps

## Why?


## How?

Conda has been added as a Datasource but not a Manager for RenovateBot, so need to follow this issue:

https://github.com/renovatebot/renovate/issues/2213

## Testing?


## Screenshots (optional)


## Anything Else?

